### PR TITLE
It's possible to miss images in a post without applying filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-.tmp_*
-.DS_Store
-.project


### PR DESCRIPTION
Hey Chuck,

If you've got a post that starts with (or is) a [gallery] shortcode then no images were being found, same would apply if images were coming from another plugin's shortcodes.

I've tested this in another branch but not against master, give it a try on your end.

Also noticed that posts with no images will trigger a php warning on no index in array - try turning on WP_DEBUG and hitting a page with no images. The moremeta branch avoids this, I'm trying a very different way of getting and rendering the meta data in that one.
