### PR TITLE
Remove SERVER_NAME usage because could be localhost with reverse proxies

### DIFF
--- a/wp-facebook-ogp.php
+++ b/wp-facebook-ogp.php
@@ -188,6 +188,7 @@ function wpfbogp_build_head() {
 
 		// Make sure there were images passed as an array and loop through/output each
 		if ( ! empty( $wpfbogp_images ) && is_array( $wpfbogp_images ) ) {
+			$wpfbogp_images = array_unique($wpfbogp_images);
 			foreach ( $wpfbogp_images as $image ) {
 				echo '<meta property="og:image" content="' . esc_url( apply_filters( 'wpfbogp_image', $image ) ) . '"/>' . "\n";
 			}

--- a/wp-facebook-ogp.php
+++ b/wp-facebook-ogp.php
@@ -120,13 +120,7 @@ function wpfbogp_build_head() {
 			echo '<meta property="fb:app_id" content="' . esc_attr( apply_filters( 'wpfbogp_app_id', $options['wpfbogp_app_id'] ) ) . '"/>' . "\n";
 		}
 
-		// do url stuff
-		if ( is_front_page() ) {
-			$wpfbogp_url = home_url();
-		} else {
-			$wpfbogp_url = 'http' . ( is_ssl() ? 's' : '' ) . '://' . $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI'];
-		}
-		echo '<meta property="og:url" content="' . esc_url( user_trailingslashit( trailingslashit( apply_filters( 'wpfbogp_url', $wpfbogp_url ) ) ) ) . '"/>' . "\n";
+		echo '<meta property="og:url" content="' . esc_url( user_trailingslashit( trailingslashit( apply_filters( 'wpfbogp_url', home_url() . $_SERVER['REQUEST_URI'] ) ) ) ) . '"/>' . "\n";
 
 		// do title stuff
 		if ( is_home() || is_front_page() ) {


### PR DESCRIPTION
I had problem with localhost values for a long time now because I always used reverse proxies like nginx or today traefik

Check my tickets:
1 year, 6 months: https://wordpress.org/support/topic/ogurl-is-always-localhost/
A few days: https://wordpress.org/support/topic/ogurl-localhost-continuing/


I tested those changes and if home_url is correctly set in general settings, I had no problem displaying og:url on frontpage or everywhere else